### PR TITLE
Allow python 3.11.x

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ description = "Colored (terminal) output/strings"
 authors = ["Jason Verbeek <jason@localhost8080.org>"]
 
 [tool.poetry.dependencies]
-python = ">=3.8,<=3.11"
+python = ">=3.8,<3.12"
 
 [tool.poetry.dev-dependencies]
 pylint = "^2.13.3"


### PR DESCRIPTION
Currently, installation with python 11 fails with error `ERROR: Packages require a different Python. 3.11.1 not in: '<=3.11,>=3.8'`.

Proposal to change python version constraint.